### PR TITLE
feat: add support for desktop

### DIFF
--- a/rating/src/commonMain/kotlin/AppRatingManager.kt
+++ b/rating/src/commonMain/kotlin/AppRatingManager.kt
@@ -14,6 +14,7 @@ import openWebBrowser
 internal class AppRatingManager(
     private val playStoreLink: String,
     private val appStoreLink: String,
+    private val desktopStoreLink: String,
 ) {
     private val timestampKey = "_appRatingManagerTimestamp"
     private val initialPeriodStateKey = "_appRatingManagerInitialPeriodState"
@@ -146,8 +147,11 @@ internal class AppRatingManager(
 
     internal fun openBrowser() {
         openWebBrowser(
-            url = if (getPlatform() == Platform.ANDROID) playStoreLink
-            else appStoreLink
+            url = when (getPlatform()) {
+                Platform.ANDROID -> playStoreLink
+                Platform.IOS -> appStoreLink
+                Platform.DESKTOP -> desktopStoreLink
+            }
         )
     }
 }

--- a/rating/src/commonMain/kotlin/presentation/component/AppRatingDialog.kt
+++ b/rating/src/commonMain/kotlin/presentation/component/AppRatingDialog.kt
@@ -82,6 +82,7 @@ fun AppRatingDialog(
     modifier: Modifier = Modifier,
     playStoreLink: String,
     appStoreLink: String,
+    desktopStoreLink: String,
     initialDelayInDays: Int = 5,
     interval: Interval = Interval.Monthly,
     title: @Composable (() -> Unit)? = { Text(text = "Enjoying our App?") },
@@ -97,7 +98,8 @@ fun AppRatingDialog(
     val appRatingManager = remember {
         AppRatingManager(
             playStoreLink,
-            appStoreLink
+            appStoreLink,
+            desktopStoreLink,
         )
     }
     val showDialog by appRatingManager.showDialog.collectAsState()

--- a/rating/src/commonMain/kotlin/util/Platform.kt
+++ b/rating/src/commonMain/kotlin/util/Platform.kt
@@ -2,7 +2,8 @@ package com.stevdza_san.demo.util
 
 enum class Platform {
     ANDROID,
-    IOS
+    IOS,
+    DESKTOP,
 }
 
 expect fun getPlatform(): Platform

--- a/rating/src/desktopMain/kotlin/util/Platform.desktop.kt
+++ b/rating/src/desktopMain/kotlin/util/Platform.desktop.kt
@@ -1,0 +1,3 @@
+package com.stevdza_san.demo.util
+
+actual fun getPlatform() = Platform.DESKTOP


### PR DESCRIPTION
This commit adds support for desktop platforms to the AppRatingManager.

The changes include:

- Adding a `desktopStoreLink` parameter to the `AppRatingManager` constructor.
- Updating the `openBrowser` function to open the appropriate store link based on the platform.
- Adding a `Platform.DESKTOP` enum value.
- Adding a `getPlatform` implementation for desktop platforms.